### PR TITLE
Make event_name locally scoped in the for() loops.

### DIFF
--- a/pagevisibilityuserscript.js
+++ b/pagevisibilityuserscript.js
@@ -22,7 +22,7 @@ let events_to_block = [
   "mouseleave"
 ]
 
-for (event_name of events_to_block) {
+for (let event_name of events_to_block) {
   document.addEventListener(event_name, function (event) {
       event.preventDefault();
       event.stopPropagation();
@@ -30,7 +30,7 @@ for (event_name of events_to_block) {
   }, true);
 }
 
-for (event_name of events_to_block) {
+for (let event_name of events_to_block) {
   window.addEventListener(event_name, function (event) {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
The Tampermonkey script editor warns that event_name is created as a global variable in the loop declarations. This commit resolves the warnings by making event_name locally scoped to the for() loops.